### PR TITLE
overwriting osfamily and operatingsystemrelease values for Amazon Linux

### DIFF
--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -1,0 +1,21 @@
+# Fact: osfamily
+#
+# Purpose: Returns the operating system
+#
+# Resolution:
+#   if the operating system is Amazon, get the operating system release from /etc/system-release
+# Caveats:
+#   This fact is completely reliant on the operatingsystem fact, and no
+#   heuristics are used
+#
+
+Facter.add(:operatingsystemrelease) do
+  has_weight 100
+  setcode do
+    case Facter.value(:operatingsystem)
+    when "Amazon"
+        lines = File.open("/etc/system-release").to_a
+        value = lines.first.split(" ")[-1]
+    end
+  end
+end

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -1,0 +1,19 @@
+# Fact: osfamily
+#
+# Purpose: Returns the operating system of Amazon linux as 'Redhat'
+# Resolution:
+#   if the operating system is Amazon, report the osfamily as 'Redhat'
+# Caveats:
+#   This fact is completely reliant on the operatingsystem fact, and no
+#   heuristics are used
+#
+
+Facter.add(:osfamily) do
+  has_weight 100
+  setcode do
+    case Facter.value(:operatingsystem)
+    when "Amazon"
+      "RedHat"
+    end
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-send_collectd_metrics",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Uday Sagar Shiramshetty",
   "summary": "A puppet module that configures write_http plugin of collectd to send the system metrics to SignalFx",
   "license": "Apache-2.0",
@@ -43,7 +43,7 @@
     }
   ],
   "dependencies": [
-    {"name":"pdxcat/collectd","version_requirement":">= 4.0.0"},
+    {"name":"puppet/collectd","version_requirement":">= 4.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.0.4"}
   ]


### PR DESCRIPTION
updated dependency from pdxcat/collectd to puppet/collectd
increased version number from 0.1.2 to 0.1.3
